### PR TITLE
check if additionalParams is an array // prevent foreach-warning

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -366,7 +366,7 @@ class FormController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
     protected function getAdditionalParams()
     {
         $additionalParams = array();
-        if(is_array($this->settings['additionalParams']) && !count($this->settings['additionalParams'])){
+        if(!is_array($this->settings['additionalParams']) || !count($this->settings['additionalParams'])){            
             return $additionalParams;
         }
         foreach ($this->settings['additionalParams'] as $additionalParam) {


### PR DESCRIPTION
to prevent PHP-warning "PHP Warning: Invalid argument supplied for foreach() in ..." 