### PR TITLE
Prevent PHP Undefined array Warning if additionalParams is not set

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -365,10 +365,14 @@ class FormController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
      */
     protected function getAdditionalParams()
     {
-        $additionalParams = array();
-        if(!is_array($this->settings['additionalParams'])){
-            return $additionalParams;
+        if (
+            !isset($this->settings['additionalParams'])
+            || !is_array($this->settings['additionalParams'])
+        ) {
+            return array();
         }
+
+        $additionalParams = array();
         foreach ($this->settings['additionalParams'] as $additionalParam) {
             if ($this->request->hasArgument($additionalParam)) {
             }


### PR DESCRIPTION
Hi Marcus,

this fixes a PHP warning if the setting key `additionalParams` is not set.